### PR TITLE
fix the firewall rule arg split error

### DIFF
--- a/neutronclient/neutron/v2_0/fw/firewallpolicy.py
+++ b/neutronclient/neutron/v2_0/fw/firewallpolicy.py
@@ -70,7 +70,7 @@ class CreateFirewallPolicy(neutronv20.CreateCommand):
             help=_('Create a shared policy.'),
             default=argparse.SUPPRESS)
         parser.add_argument(
-            '--firewall-rules', type=str.split,
+            '--firewall-rules', type=lambda x: x.split(),
             help=_('Ordered list of whitespace-delimited firewall rule '
                    'names or IDs; e.g., --firewall-rules \"rule1 rule2\"'))
         parser.add_argument(

--- a/neutronclient/tests/unit/fw/test_cli20_firewallpolicy.py
+++ b/neutronclient/tests/unit/fw/test_cli20_firewallpolicy.py
@@ -47,31 +47,33 @@ class CLITestV20FirewallPolicyJSON(test_cli20.CLITestV20Base):
                                    admin_state_up=True, tenant_id=tenant_id)
 
     def test_create_firewall_policy_with_all_params(self):
-        """firewall-policy-create with all params set."""
+        """firewall-policy-create with rule param of misc format."""
         resource = 'firewall_policy'
         cmd = firewallpolicy.CreateFirewallPolicy(test_cli20.MyApp(sys.stdout),
                                                   None)
         name = 'my-name'
         description = 'my-desc'
-        firewall_rules_arg = 'rule_id1 rule_id2'
         firewall_rules_res = ['rule_id1', 'rule_id2']
         tenant_id = 'my-tenant'
         my_id = 'myid'
-        args = ['--description', description,
-                '--shared',
-                '--firewall-rules', firewall_rules_arg,
-                '--audited',
-                '--tenant-id', tenant_id,
-                '--admin-state_up',
-                name]
         position_names = ['name', ]
         position_values = [name, ]
-        self._test_create_resource(resource, cmd, name, my_id, args,
-                                   position_names, position_values,
-                                   description=description, shared=True,
-                                   firewall_rules=firewall_rules_res,
-                                   audited=True, admin_state_up=True,
-                                   tenant_id=tenant_id)
+
+        #check for both str and unicode format firewall_rules_arg
+        for firewall_rules_arg in ['rule_id1 rule_id2', u'rule_id1 rule_id2']:
+            args = ['--description', description,
+                    '--shared',
+                    '--firewall-rules', firewall_rules_arg,
+                    '--audited',
+                    '--tenant-id', tenant_id,
+                    '--admin-state_up',
+                    name]
+            self._test_create_resource(resource, cmd, name, my_id, args,
+                                       position_names, position_values,
+                                       description=description, shared=True,
+                                       firewall_rules=firewall_rules_res,
+                                       audited=True, admin_state_up=True,
+                                       tenant_id=tenant_id)
 
     def test_list_firewall_policies(self):
         """firewall-policy-list."""


### PR DESCRIPTION
the previous firewall rules parsing is for type 'string', but we add the
capability to deal with type 'unicode' to match the real type from cmdline.

Fixes: redmine #3720

Change-Id: Id673a0c5967131d9d88fe0c78f19613a6fc1c721
Closes-Bug: 1385908
(cherry picked from commit 8a7771844daf9015644e07acbac05664d5260b64)
Signed-off-by: huntxu mhuntxu@gmail.com
