### PR TITLE
neutron-CLI: Add support lbaas add/remove command

### DIFF
--- a/neutronclient/neutron/v2_0/agentscheduler.py
+++ b/neutronclient/neutron/v2_0/agentscheduler.py
@@ -275,3 +275,53 @@ class GetLbaasAgentHostingPool(neutronV20.ListCommand):
         agent = neutron_client.get_lbaas_agent_hosting_pool(**search_opts)
         data = {'agents': [agent['agent']]}
         return data
+
+
+class AddPoolToLbAgent(neutronV20.NeutronCommand):
+    """Add a pool to a lbaas agent."""
+
+    def get_parser(self, prog_name):
+        parser = super(AddPoolToLbAgent, self).get_parser(prog_name)
+        parser.add_argument(
+            'lb_agent',
+            help=_('ID of the Lb agent.'))
+        parser.add_argument(
+            'pool',
+            help=_('Pool to add.'))
+        return parser
+
+    def run(self, parsed_args):
+        self.log.debug('run(%s)' % parsed_args)
+        neutron_client = self.get_client()
+        neutron_client.format = parsed_args.request_format
+        _id = neutronV20.find_resourceid_by_name_or_id(
+            neutron_client, 'pool', parsed_args.pool)
+        neutron_client.add_pool_to_lb_agent(parsed_args.lb_agent,
+                                            {'pool_id': _id})
+        print(_('Added pool %s to Lb agent') % parsed_args.pool,
+              file=self.app.stdout)
+
+
+class RemovePoolFromLbAgent(neutronV20.NeutronCommand):
+    """Remove a pool from a lbaas agent."""
+
+    def get_parser(self, prog_name):
+        parser = super(RemovePoolFromLbAgent, self).get_parser(prog_name)
+        parser.add_argument(
+            'lb_agent',
+            help=_('ID of the Lb agent.'))
+        parser.add_argument(
+            'pool',
+            help=_('Pool to remove.'))
+        return parser
+
+    def run(self, parsed_args):
+        self.log.debug('run(%s)' % parsed_args)
+        neutron_client = self.get_client()
+        neutron_client.format = parsed_args.request_format
+        _id = neutronV20.find_resourceid_by_name_or_id(
+            neutron_client, 'pool', parsed_args.pool)
+        neutron_client.remove_pool_from_lb_agent(
+            parsed_args.lb_agent, _id)
+        print(_('Removed pool %s from Lb agent') % parsed_args.pool,
+              file=self.app.stdout)

--- a/neutronclient/shell.py
+++ b/neutronclient/shell.py
@@ -221,6 +221,8 @@ COMMAND_V2 = {
     'l3-agent-list-hosting-router': agentscheduler.ListL3AgentsHostingRouter,
     'lb-pool-list-on-agent': agentscheduler.ListPoolsOnLbaasAgent,
     'lb-agent-hosting-pool': agentscheduler.GetLbaasAgentHostingPool,
+    'lb-agent-pool-add': agentscheduler.AddPoolToLbAgent,
+    'lb-agent-pool-remove': agentscheduler.RemovePoolFromLbAgent,
     'service-provider-list': servicetype.ListServiceProvider,
     'firewall-rule-list': firewallrule.ListFirewallRule,
     'firewall-rule-show': firewallrule.ShowFirewallRule,

--- a/neutronclient/v2_0/client.py
+++ b/neutronclient/v2_0/client.py
@@ -799,6 +799,18 @@ class Client(object):
         return self.delete(path)
 
     @APIParamsCall
+    def add_pool_to_lb_agent(self, lb_agent, body):
+        """Add a pool to Lbaas agent."""
+        return self.post((self.agent_path + self.LOADBALANCER_POOLS) %
+                         lb_agent, body=body)
+
+    @APIParamsCall
+    def remove_pool_from_lb_agent(self, lb_agent, pool_id):
+        """Remove a pool from Lbaas agent."""
+        return self.delete((self.agent_path + self.LOADBALANCER_POOLS +
+                            "/%s") % (lb_agent, pool_id))
+
+    @APIParamsCall
     def create_qos_queue(self, body=None):
         """Creates a new queue."""
         return self.post(self.qos_queues_path, body=body)


### PR DESCRIPTION
This change enable neutron subcommand lb-agent-pool-add
and lb-agent-pool-remove to add/remove a pool to/from
lbaas agent

Fixes: #7581

Signed-off-by: cheng.tang tangch318@gmail.com
