### PR TITLE
VPNaaS: deprecate two dpd actions

### DIFF
--- a/neutronclient/neutron/v2_0/vpn/utils.py
+++ b/neutronclient/neutron/v2_0/vpn/utils.py
@@ -23,8 +23,7 @@
 from neutronclient.common import exceptions
 from neutronclient.openstack.common.gettextutils import _
 
-dpd_supported_actions = ['hold', 'clear', 'restart',
-                         'restart-by-peer', 'disabled']
+dpd_supported_actions = ['hold', 'clear', 'restart']
 dpd_supported_keys = ['action', 'interval', 'timeout']
 
 lifetime_keys = ['units', 'value']
@@ -106,7 +105,7 @@ def lifetime_help(policy):
 
 def dpd_help(policy):
     dpd = _(" %s Dead Peer Detection attributes."
-            " 'action'-hold,clear,disabled,restart,restart-by-peer."
+            " 'action'-hold,clear,restart."
             " 'interval' and 'timeout' are non negative integers. "
             " 'interval' should be less than 'timeout' value. "
             " 'action', default:hold 'interval', default:30, "

--- a/neutronclient/tests/unit/vpn/test_utils.py
+++ b/neutronclient/tests/unit/vpn/test_utils.py
@@ -36,18 +36,8 @@ class TestVPNUtils(testtools.TestCase):
         input_str = utils.str2dict("action=restart,interval=30,timeout=120")
         self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
 
-    def test_validate_dpd_dictionary_action_restart_by_peer(self):
-        input_str = utils.str2dict(
-            "action=restart-by-peer,interval=30,timeout=120"
-        )
-        self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
-
     def test_validate_dpd_dictionary_action_clear(self):
         input_str = utils.str2dict('action=clear,interval=30,timeout=120')
-        self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
-
-    def test_validate_dpd_dictionary_action_disabled(self):
-        input_str = utils.str2dict('action=disabled,interval=30,timeout=120')
         self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
 
     def test_validate_lifetime_dictionary_invalid_unit_key(self):


### PR DESCRIPTION
Deprecate 'restart-by-peer' and 'disabled'.

Fixes: redmine #8874

See eayunstack/neutron#47

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>